### PR TITLE
Enable mouse button navigation in Visual Studio

### DIFF
--- a/MacKeyboardNorwegian.ahk
+++ b/MacKeyboardNorwegian.ahk
@@ -227,5 +227,8 @@ Shift & '::SendInput {NumpadMult}
 ;^l::return
 ;#l::SendInput ^{l}
 
+; Visual Studio
+; Mouse button 4/5 Navigate forward/backward
+#IfWinActive ahk_exe devenv.exe
+#XButton1::SendInput, {Ctrl Down}{-}{Ctrl Up}
 
-#IfWinActive


### PR DESCRIPTION
Binds mousebutton 4/5 to forward/backward navigation in code in
Visual Studio. Default hotkeys in VS for navigation should be set: (shift)+ctrl+-